### PR TITLE
made set locations modal

### DIFF
--- a/src/components/user-management/LocationSelectionModal.tsx
+++ b/src/components/user-management/LocationSelectionModal.tsx
@@ -1,0 +1,157 @@
+import React, { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Button,
+  Checkbox,
+} from "@heroui/react";
+import { axiosPrivate } from "../../services/axiosClient";
+import { Location } from "../../types/location";
+
+interface LocationSelectionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  userId: number;
+  userName: string;
+  locations: Location[];
+  selectedLocationIds: number[];
+}
+
+const LocationSelectionModal: React.FC<LocationSelectionModalProps> = ({
+  isOpen,
+  onClose,
+  userId,
+  userName,
+  locations,
+  selectedLocationIds,
+}) => {
+  const { t } = useTranslation();
+  const [error, setError] = useState<string | null>(null);
+  const [selectedLocations, setSelectedLocations] = useState<Set<number>>(
+    new Set(selectedLocationIds)
+  );
+  const [saving, setSaving] = useState<boolean>(false);
+
+  // Fetch all available locations when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedLocations(new Set(selectedLocationIds));
+    }
+  }, [isOpen, selectedLocationIds]);
+
+  // Check if all locations are selected
+  const allSelected =
+    locations.length > 0 &&
+    locations.every((location) => selectedLocations.has(location.id));
+
+  // Handle "All locations" checkbox change
+  const handleAllLocationsChange = (checked: boolean) => {
+    if (checked) {
+      const allLocationIds = locations.map((location) => location.id);
+      setSelectedLocations(new Set(allLocationIds));
+    } else {
+      setSelectedLocations(new Set());
+    }
+  };
+
+  // Handle individual location checkbox change
+  const handleLocationChange = (locationId: number, checked: boolean) => {
+    setSelectedLocations((prev) => {
+      const newSet = new Set(prev);
+      if (checked) {
+        newSet.add(locationId);
+      } else {
+        newSet.delete(locationId);
+      }
+      return newSet;
+    });
+  };
+
+  // Save changes
+  const handleApply = async () => {
+    try {
+      setSaving(true);
+      await axiosPrivate.post("/locations/locations", {
+        userId: userId,
+        location_ids: Array.from(selectedLocations),
+      });
+      
+      onClose();
+      // Reload page or update data
+      window.location.reload();
+    } catch (err) {
+      console.error("Error updating user locations:", err);
+      setError("Failed to update locations");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="md">
+      <ModalContent>
+        <ModalHeader>
+          <div className="text-xl font-medium">
+            {t("user.selectLocations", "Select Locations for")}: {userName}
+          </div>
+        </ModalHeader>
+        <ModalBody>
+          {error ? (
+            <div className="bg-danger-50 text-danger p-4 rounded">
+              {error}
+            </div>
+          ) : (
+            <div className="flex flex-col space-y-4">
+              <div className="flex items-center">
+                <Checkbox
+                  id="select-all-locations"
+                  isSelected={allSelected}
+                  isIndeterminate={selectedLocations.size > 0 && !allSelected}
+                  onValueChange={handleAllLocationsChange}
+                >
+                  {t("location.allLocations", "All Locations")}
+                </Checkbox>
+              </div>
+
+              <div className="divider my-2 h-px bg-gray-200" />
+
+              <div className="ml-4 flex flex-col space-y-2">
+                {locations.map((location) => (
+                  <Checkbox
+                    key={`location-${location.id}`}
+                    id={`location-${location.id}`}
+                    isSelected={selectedLocations.has(location.id)}
+                    onValueChange={(checked) =>
+                      handleLocationChange(location.id, checked)
+                    }
+                  >
+                    {location.name}
+                  </Checkbox>
+                ))}
+              </div>
+            </div>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" onPress={onClose} className="mr-2">
+            {t("common.cancel", "Cancel")}
+          </Button>
+          <Button 
+            variant="solid"
+            onPress={handleApply} 
+            isDisabled={saving}
+            isLoading={saving}
+          >
+            {t("common.apply", "Apply")}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default LocationSelectionModal;

--- a/src/components/user-management/UserByLocationList.tsx
+++ b/src/components/user-management/UserByLocationList.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useUsersByLocations } from "../../hooks/users/useUsersByLocations";
 import { UserWithLocations } from "../../types/location";
 import {
@@ -9,10 +10,40 @@ import {
   TableCell,
   Spinner,
   Chip,
+  Button,
 } from "@heroui/react";
+import LocationSelectionModal from "./LocationSelectionModal";
+import { useFetchLocations } from "../../hooks/users/useFetchLocations";
 
 export default function UserByLocationList() {
-  const { users, loading, error } = useUsersByLocations();
+  const {
+    users,
+    loading: usersLoading,
+    error: usersError,
+  } = useUsersByLocations();
+  const {
+    locations,
+    loading: locationsLoading,
+    error: locationsError,
+  } = useFetchLocations();
+  const loading = usersLoading || locationsLoading;
+  const error = usersError || locationsError;
+  const [selectedUser, setSelectedUser] = useState<UserWithLocations | null>(
+    null,
+  );
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // Function to open the location selection modal
+  const handleEditLocations = (user: UserWithLocations) => {
+    setSelectedUser(user);
+    setIsModalOpen(true);
+  };
+
+  // Function to close the modal
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setSelectedUser(null);
+  };
 
   // Function to render location names with emojis
   const renderLocations = (locations: UserWithLocations["locations"]) => {
@@ -46,6 +77,7 @@ export default function UserByLocationList() {
     { key: "email", label: "EMAIL" },
     { key: "role", label: "ROLE" },
     { key: "locations", label: "LOCATIONS" },
+    { key: "actions", label: "ACTIONS" },
   ];
 
   return (
@@ -79,17 +111,44 @@ export default function UserByLocationList() {
               <TableColumn key={column.key}>{column.label}</TableColumn>
             )}
           </TableHeader>
-          <TableBody items={users} emptyContent={<p>No users found</p>}>
+          <TableBody
+            items={[...users].sort((a, b) => a.name.localeCompare(b.name))}
+            emptyContent={<p>No users found</p>}
+          >
             {(user) => (
               <TableRow key={user.id}>
                 <TableCell>{user.name}</TableCell>
                 <TableCell>{user.email}</TableCell>
                 <TableCell>{renderRole(user.role)}</TableCell>
-                <TableCell>{renderLocations(user.locations)}</TableCell>
+                <TableCell>
+                  {renderLocations(
+                    user.locations.sort((a, b) => a.name.localeCompare(b.name)),
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Button
+                    size="sm"
+                    onPress={() => handleEditLocations(user)}
+                    color="primary"
+                  >
+                    Edit Locations
+                  </Button>
+                </TableCell>
               </TableRow>
             )}
           </TableBody>
         </Table>
+      )}
+
+      {selectedUser && (
+        <LocationSelectionModal
+          isOpen={isModalOpen}
+          locations={locations}
+          onClose={handleCloseModal}
+          userId={selectedUser.id}
+          userName={selectedUser.name}
+          selectedLocationIds={selectedUser.locations.map((loc) => loc.id)}
+        />
       )}
     </div>
   );

--- a/src/hooks/users/useFetchLocations.ts
+++ b/src/hooks/users/useFetchLocations.ts
@@ -1,0 +1,26 @@
+import { axiosPrivate } from "../../services/axiosClient.ts";
+import { useEffect, useState } from "react";
+import { Location } from "../../types/location.ts";
+
+export const useFetchLocations = () => {
+  const [locations, setLocations] = useState<Location[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchLocations = async () => {
+      try {
+        const response = await axiosPrivate.get("/locations");
+        setLocations(response.data);
+      } catch (err) {
+        setError("Failed to fetch locations");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchLocations();
+  }, []);
+
+  return { locations, loading, error };
+};


### PR DESCRIPTION
This pull request introduces a feature allowing users to manage locations associated with individual users. It includes the implementation of a new modal component for location selection, integration of this modal into the user list, and a custom hook for fetching location data. Below are the most important changes grouped by theme:

### New Component for Location Management
* **`LocationSelectionModal.tsx`**: Added a new modal component that allows administrators to select and save locations for a specific user. This includes functionality for selecting all locations, handling individual location selections, and saving changes via an API call.

### Integration into User Management
* **`UserByLocationList.tsx`**: Integrated the `LocationSelectionModal` into the user list, adding an "Edit Locations" button for each user. This enables administrators to open the modal and manage locations directly from the user list. The table now includes an "Actions" column for this functionality. [[1]](diffhunk://#diff-8467c5f7c398c0ba180ffb54c6173ece4dec0327bd1fafb97e9090a198bed9f8R13-R46) [[2]](diffhunk://#diff-8467c5f7c398c0ba180ffb54c6173ece4dec0327bd1fafb97e9090a198bed9f8R80) [[3]](diffhunk://#diff-8467c5f7c398c0ba180ffb54c6173ece4dec0327bd1fafb97e9090a198bed9f8L82-R152)

### Data Fetching for Locations
* **`useFetchLocations.ts`**: Created a custom hook to fetch location data from the API. This hook manages loading and error states, ensuring the location data is available for use in the modal and user list components.