### PR TITLE
fix timezones

### DIFF
--- a/src/hooks/sensor-data/group-data/aggregate-time-series-service.ts
+++ b/src/hooks/sensor-data/group-data/aggregate-time-series-service.ts
@@ -23,7 +23,8 @@ const aggregateTimeSeries = (
   >();
 
   data.forEach((point) => {
-    const date = parseISO(point.timestamp.replace("Z", "")); // Remove 'Z' for consistency
+    // Parse the ISO timestamp directly (keeping the Z if present) to properly handle UTC time
+    const date = parseISO(point.timestamp);
     const strategy: TimeGroupingStrategy = timeGroupingStrategies[timeAmount]!;
     const groupKey = strategy.getGroupKey(date);
 


### PR DESCRIPTION
This pull request includes a small but important change to the `aggregate-time-series-service.ts` file. The change ensures proper handling of UTC time when parsing ISO timestamps by no longer removing the 'Z' suffix from the timestamp string.