### PR TITLE
fix sensor selection by name to by id

### DIFF
--- a/src/components/dashboard/filter.tsx
+++ b/src/components/dashboard/filter.tsx
@@ -15,14 +15,14 @@ import { SensorLocation } from "../../types/sensorLocation.ts";
 type DashboardFiltersProps = {
   onDateRangeChange: (startDate: Date, endDate: Date) => void;
   currentDateRange: { start: Date; end: Date };
-  onSensorsChange: (sensors: string[]) => void;
+  onSensorsChange: (sensors: number[]) => void;
   onAggregationChange?: (aggregation: string) => void;
   hourRange: { start: Time; end: Time };
   onHourRangeChange: (start: Time, end: Time) => void;
   currentAggregation?: string;
   onRefreshData?: () => void;
   locations: SensorLocation[];
-  currentSensors: string[];
+  currentSensors: number[];
   lastUpdated: Date | null;
 };
 

--- a/src/components/dashboard/sensors/SensorSelectionModal.tsx
+++ b/src/components/dashboard/sensors/SensorSelectionModal.tsx
@@ -18,8 +18,8 @@ interface SensorSelectionModalProps {
   isOpen: boolean;
   onClose: () => void;
   locations: SensorLocation[];
-  selectedSensors: string[];
-  onSensorsChange: (sensors: string[]) => void;
+  selectedSensors: number[];
+  onSensorsChange: (sensors: number[]) => void;
 }
 
 const SensorSelectionModal: React.FC<SensorSelectionModalProps> = ({
@@ -32,7 +32,7 @@ const SensorSelectionModal: React.FC<SensorSelectionModalProps> = ({
   const { t } = useTranslation();
 
   // Local state for tracking selected sensors within the modal
-  const [localSelectedSensors, setLocalSelectedSensors] = useState<Set<string>>(
+  const [localSelectedSensors, setLocalSelectedSensors] = useState<Set<number>>(
     new Set(selectedSensors),
   );
 
@@ -50,7 +50,7 @@ const SensorSelectionModal: React.FC<SensorSelectionModalProps> = ({
 
   // Helper to get all sensors across all locations
   const allSensors = locations.flatMap((location) =>
-    location.sensors.map((sensor: sensorMetadata) => sensor.position),
+    location.sensors.map((sensor: sensorMetadata) => sensor.id),
   );
 
   // Check if all sensors are selected in local state
@@ -68,7 +68,7 @@ const SensorSelectionModal: React.FC<SensorSelectionModalProps> = ({
   };
 
   // Handle location checkbox change
-  const handleLocationChange = (sensors: string[], checked: boolean) => {
+  const handleLocationChange = (sensors: number[], checked: boolean) => {
     if (checked) {
       // Add all sensors from this location
       setLocalSelectedSensors((prev) => {
@@ -87,7 +87,7 @@ const SensorSelectionModal: React.FC<SensorSelectionModalProps> = ({
   };
 
   // Handle individual sensor checkbox change
-  const handleSensorChange = (sensor: string, checked: boolean) => {
+  const handleSensorChange = (sensor: number, checked: boolean) => {
     setLocalSelectedSensors((prev) => {
       const newSet = new Set(prev);
       if (checked) {
@@ -106,7 +106,7 @@ const SensorSelectionModal: React.FC<SensorSelectionModalProps> = ({
   };
 
   // Check if all sensors in a location are selected
-  const areAllLocationSensorsSelected = (sensors: string[]): boolean => {
+  const areAllLocationSensorsSelected = (sensors: number[]): boolean => {
     return (
       sensors.length > 0 &&
       sensors.every((sensor) => localSelectedSensors.has(sensor))
@@ -114,7 +114,7 @@ const SensorSelectionModal: React.FC<SensorSelectionModalProps> = ({
   };
 
   // Check if some (but not all) sensors in a location are selected
-  const areSomeLocationSensorsSelected = (sensors: string[]): boolean => {
+  const areSomeLocationSensorsSelected = (sensors: number[]): boolean => {
     return (
       sensors.some((sensor) => localSelectedSensors.has(sensor)) &&
       !sensors.every((sensor) => localSelectedSensors.has(sensor))
@@ -144,7 +144,7 @@ const SensorSelectionModal: React.FC<SensorSelectionModalProps> = ({
             <Accordion className="gap-2">
               {locations.map((location) => {
                 const locationSensors = location.sensors.map(
-                  (sensor: sensorMetadata) => sensor.position,
+                  (sensor: sensorMetadata) => sensor.id,
                 );
                 const allChecked =
                   areAllLocationSensorsSelected(locationSensors);
@@ -180,9 +180,9 @@ const SensorSelectionModal: React.FC<SensorSelectionModalProps> = ({
                           key={`sensor-${location.id}-${sensor.id}`}
                           id={`sensor-${location.id}-${sensor.id}`}
                           label={sensor.position}
-                          checked={localSelectedSensors.has(sensor.position)}
+                          checked={localSelectedSensors.has(sensor.id)}
                           onChange={(checked) =>
-                            handleSensorChange(sensor.position, checked)
+                            handleSensorChange(sensor.id, checked)
                           }
                         />
                       ))}

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -78,14 +78,14 @@ const Dashboard = () => {
     }));
   };
 
-  const handleSensorsChange = (sensors: string[]) => {
+  const handleSensorsChange = (sensors: number[]) => {
     setSensorRecordsFormData((prev: SensorRecordsFormData) => {
       return {
         ...prev,
         sensorIds: sensors
           .map((sensor) => {
             const sensorEntry = Array.from(sensorMap.entries()).find(
-              ([, position]) => position === sensor,
+              ([id]) => id === sensor,
             );
             return sensorEntry ? sensorEntry[0] : null;
           })
@@ -200,7 +200,7 @@ const Dashboard = () => {
         currentDateRange={sensorRecordsFormData.dateRange}
         onSensorsChange={handleSensorsChange}
         currentSensors={
-          sensorRecordsFormData.sensorIds?.map((id) => sensorMap.get(id)!) || []
+          sensorRecordsFormData.sensorIds?.map((id) => id) || []
         }
         hourRange={sensorRecordsFormData.hourRange}
         onHourRangeChange={handleHourRangeChange}


### PR DESCRIPTION
This pull request updates the codebase to use sensor IDs (`number`) instead of sensor positions (`string`) as the primary identifier for sensors. Additionally, it introduces enhancements to improve clarity when displaying sensor names, especially in cases of duplicate positions across different locations.

### Transition to Sensor IDs as Primary Identifiers:
* [`src/components/dashboard/filter.tsx`](diffhunk://#diff-566420ecbb6acc90a6cbc0c280f6cf6a1df60bebb4c2a4216c47b66c6b41b8faL18-R25): Updated `onSensorsChange` and `currentSensors` properties in `DashboardFiltersProps` to use `number[]` instead of `string[]`.
* [`src/components/dashboard/sensors/SensorSelectionModal.tsx`](diffhunk://#diff-04937b00ea196f6a10cdcded7eabf95d9260323371bd83ee837787918c173f4cL21-R22): Modified `SensorSelectionModalProps` and related logic to use sensor IDs (`number`) instead of positions (`string`) for selected sensors and local state. [[1]](diffhunk://#diff-04937b00ea196f6a10cdcded7eabf95d9260323371bd83ee837787918c173f4cL21-R22) [[2]](diffhunk://#diff-04937b00ea196f6a10cdcded7eabf95d9260323371bd83ee837787918c173f4cL35-R35) [[3]](diffhunk://#diff-04937b00ea196f6a10cdcded7eabf95d9260323371bd83ee837787918c173f4cL53-R53) [[4]](diffhunk://#diff-04937b00ea196f6a10cdcded7eabf95d9260323371bd83ee837787918c173f4cL71-R71) [[5]](diffhunk://#diff-04937b00ea196f6a10cdcded7eabf95d9260323371bd83ee837787918c173f4cL90-R90) [[6]](diffhunk://#diff-04937b00ea196f6a10cdcded7eabf95d9260323371bd83ee837787918c173f4cL109-R117) [[7]](diffhunk://#diff-04937b00ea196f6a10cdcded7eabf95d9260323371bd83ee837787918c173f4cL147-R147) [[8]](diffhunk://#diff-04937b00ea196f6a10cdcded7eabf95d9260323371bd83ee837787918c173f4cL183-R185)
* [`src/pages/dashboard.tsx`](diffhunk://#diff-b681b71028a80956c734959f0977f7d1c526d44cd0962324f9dfd3059aae59f1L81-R88): Updated `handleSensorsChange` and `currentSensors` logic to align with the new sensor ID-based approach. [[1]](diffhunk://#diff-b681b71028a80956c734959f0977f7d1c526d44cd0962324f9dfd3059aae59f1L81-R88) [[2]](diffhunk://#diff-b681b71028a80956c734959f0977f7d1c526d44cd0962324f9dfd3059aae59f1L203-R203)

### Enhancements to Sensor Naming:
* [`src/pages/comparison.tsx`](diffhunk://#diff-13a3f9a0526bed49a94f3e94c8d23b2981da13a93da69f543f250cd759da05adL39-R39): Updated `sensorMap` to include both position and location name for sensors. Added logic to append location names to sensor positions if duplicates exist across locations, improving clarity in charts and comparisons. [[1]](diffhunk://#diff-13a3f9a0526bed49a94f3e94c8d23b2981da13a93da69f543f250cd759da05adL39-R39) [[2]](diffhunk://#diff-13a3f9a0526bed49a94f3e94c8d23b2981da13a93da69f543f250cd759da05adR111-R157) [[3]](diffhunk://#diff-13a3f9a0526bed49a94f3e94c8d23b2981da13a93da69f543f250cd759da05adL169-R210)