### PR TITLE
- Removed the exportUrl field from the FormData interface in ConnectionModal, simplifying the form structure.

### DIFF
--- a/src/components/connections/ConnectionModal.tsx
+++ b/src/components/connections/ConnectionModal.tsx
@@ -38,7 +38,6 @@ interface FormData {
   name: string;
   provider: ProviderType | "";
   authFields: Record<string, string>;
-  exportUrl: string;
 }
 
 const ConnectionModal: React.FC<ConnectionModalProps> = ({
@@ -57,7 +56,6 @@ const ConnectionModal: React.FC<ConnectionModalProps> = ({
     name: "",
     provider: "",
     authFields: {},
-    exportUrl: "",
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -96,14 +94,12 @@ const ConnectionModal: React.FC<ConnectionModalProps> = ({
           name: connection.name,
           provider: connection.provider,
           authFields,
-          exportUrl: connection.exportUrl || "",
         });
       } else {
         setFormData({
           name: "",
           provider: "",
           authFields: {},
-          exportUrl: "",
         });
       }
       setErrors({});
@@ -170,7 +166,6 @@ const ConnectionModal: React.FC<ConnectionModalProps> = ({
         provider,
         businessId: parseInt(businessId, 10),
         authParams,
-        exportUrl: formData.exportUrl,
       };
 
       const success = await onTestConnection(testInput);
@@ -257,7 +252,6 @@ const ConnectionModal: React.FC<ConnectionModalProps> = ({
       provider,
       businessId: parseInt(businessId, 10),
       authParams,
-      exportUrl: formData.exportUrl,
     };
  
     const success = await onSubmit(submitData);
@@ -342,18 +336,6 @@ const ConnectionModal: React.FC<ConnectionModalProps> = ({
                 }
               />
             ))}
-
-            {formData.provider === 'FootfallCamV9API' && (
-              <Input
-                label={t("connections.auth.exportUrl", "Export URL")}
-                placeholder={t("connections.auth.exportUrlPlaceholder", "Enter export URL")}
-                value={formData.exportUrl}
-                onChange={(e) => handleInputChange("exportUrl", e.target.value)}
-                isInvalid={!!errors.exportUrl}
-                errorMessage={errors.exportUrl}
-                isRequired
-              />
-            )}
 
             {/* Test Connection Section */}
             <div className="space-y-2">

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -503,10 +503,8 @@
     "auth": {
       "user": "Usuario",
       "password": "Password",
-      "exportUrl": "Export URL",
       "userPlaceholder": "Enter username",
-      "passwordPlaceholder": "Enter password",
-      "exportUrlPlaceholder": "Enter export URL"
+      "passwordPlaceholder": "Enter password"
     }
   }
 }

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -24,7 +24,6 @@ export interface Connection extends BaseConnection {
   name: string;
   provider: ProviderType;
   authParams: AuthParams; // user, password
-  exportUrl?: string; // for FootfallCam
 }
 
 export interface CreateConnectionInput {
@@ -32,13 +31,11 @@ export interface CreateConnectionInput {
   provider: ProviderType;
   businessId: number;
   authParams: AuthParams;
-  exportUrl?: string;
 }
 
 export interface UpdateConnectionInput {
   name?: string;
   authParams?: Partial<AuthParams>;
-  exportUrl?: string;
 }
 
 export interface ConnectionsService {


### PR DESCRIPTION
This pull request removes support for the `exportUrl` field from the connection modal and related types. The changes simplify the connection creation and editing process by eliminating the `exportUrl` input for the `FootfallCamV9API` provider and cleaning up unused references throughout the codebase.

**Removal of `exportUrl` field and related logic:**

* Removed the `exportUrl` property from the `FormData` interface and all usages in the `ConnectionModal` component, including initialization, state updates, and form submission logic. [[1]](diffhunk://#diff-2d10fe8a84be11e998e5d430317aa7d09ed5069c9631f4a7af4e281701831d7aL41) [[2]](diffhunk://#diff-2d10fe8a84be11e998e5d430317aa7d09ed5069c9631f4a7af4e281701831d7aL60) [[3]](diffhunk://#diff-2d10fe8a84be11e998e5d430317aa7d09ed5069c9631f4a7af4e281701831d7aL99-L106) [[4]](diffhunk://#diff-2d10fe8a84be11e998e5d430317aa7d09ed5069c9631f4a7af4e281701831d7aL173) [[5]](diffhunk://#diff-2d10fe8a84be11e998e5d430317aa7d09ed5069c9631f4a7af4e281701831d7aL260)
* Removed the conditional rendering of the `exportUrl` input field for the `FootfallCamV9API` provider in `ConnectionModal.tsx`.

**Cleanup of types and translations:**

* Removed the `exportUrl` property from the `Connection`, `CreateConnectionInput`, and `UpdateConnectionInput` interfaces in `connection.ts`.
* Deleted unused translation keys related to `exportUrl` from the Spanish i18n file (`es.json`).