### PR TITLE
compare by local implemented

### DIFF
--- a/src/components/dashboard/filter.tsx
+++ b/src/components/dashboard/filter.tsx
@@ -45,6 +45,10 @@ type DashboardFiltersProps = {
   showComparison?: boolean;
   isComparisonEnabled?: boolean;
   onComparisonToggle?: (enabled: boolean) => void;
+  // Local aggregation props
+  showLocalToggle?: boolean;
+  isLocalAggregationEnabled?: boolean;
+  onLocalAggregationToggle?: (enabled: boolean) => void;
 };
 
 export const DashboardFilters: React.FC<DashboardFiltersProps> = ({
@@ -65,6 +69,10 @@ export const DashboardFilters: React.FC<DashboardFiltersProps> = ({
   showComparison = false,
   isComparisonEnabled = false,
   onComparisonToggle,
+  // Local aggregation props
+  showLocalToggle = false,
+  isLocalAggregationEnabled = false,
+  onLocalAggregationToggle,
 }) => {
   const { t } = useTranslation();
   const [startDate, setStartDate] = useState<DateValue>(() => {
@@ -395,6 +403,23 @@ export const DashboardFilters: React.FC<DashboardFiltersProps> = ({
                 size="sm"
                 color="primary"
                 aria-label={t("filters.comparison.toggle")}
+              ></Switch>
+            </div>
+          </div>
+        )}
+
+        {showLocalToggle && (
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-700">
+              Aggregate by Local
+            </label>
+            <div className="flex items-center h-full">
+              <Switch
+                isSelected={isLocalAggregationEnabled}
+                onValueChange={onLocalAggregationToggle}
+                size="sm"
+                color="primary"
+                aria-label="Aggregate by Local"
               ></Switch>
             </div>
           </div>


### PR DESCRIPTION
This pull request introduces a new "Aggregate by Local" feature to the comparison dashboard, allowing users to group sensor data by location and view aggregated results. It also refactors the data processing logic to improve stability and performance, and cleans up unused code related to data refresh. The most important changes are grouped below:

**Feature Addition: Local Aggregation Toggle**
* Added new props (`showLocalToggle`, `isLocalAggregationEnabled`, `onLocalAggregationToggle`) to the `DashboardFilters` component and its props type, and implemented a UI toggle for local aggregation in the dashboard filter panel. [[1]](diffhunk://#diff-566420ecbb6acc90a6cbc0c280f6cf6a1df60bebb4c2a4216c47b66c6b41b8faR48-R51) [[2]](diffhunk://#diff-566420ecbb6acc90a6cbc0c280f6cf6a1df60bebb4c2a4216c47b66c6b41b8faR72-R75) [[3]](diffhunk://#diff-566420ecbb6acc90a6cbc0c280f6cf6a1df60bebb4c2a4216c47b66c6b41b8faR410-R426)
* Integrated the local aggregation toggle into the comparison page, with state management and handler to enable/disable aggregation by location. [[1]](diffhunk://#diff-13a3f9a0526bed49a94f3e94c8d23b2981da13a93da69f543f250cd759da05adL38-R42) [[2]](diffhunk://#diff-13a3f9a0526bed49a94f3e94c8d23b2981da13a93da69f543f250cd759da05adL269-R334) [[3]](diffhunk://#diff-13a3f9a0526bed49a94f3e94c8d23b2981da13a93da69f543f250cd759da05adR381-R383)

**Data Aggregation Logic**
* Implemented logic to aggregate sensor data by location when the local aggregation toggle is enabled, grouping sensors by location and summing their values for chart display. [[1]](diffhunk://#diff-13a3f9a0526bed49a94f3e94c8d23b2981da13a93da69f543f250cd759da05adR129-R190) [[2]](diffhunk://#diff-13a3f9a0526bed49a94f3e94c8d23b2981da13a93da69f543f250cd759da05adL167-R246)

**Performance and Stability Improvements**
* Refactored the `useSensorRecords` hook to use refs for stable function references, preventing unnecessary callback recreations and improving dependency management. [[1]](diffhunk://#diff-1f4b6a605f0b4df4f1f874209b84a8c68eab4b5a6da2ba7c2646c68ad538ce95R59-R65) [[2]](diffhunk://#diff-1f4b6a605f0b4df4f1f874209b84a8c68eab4b5a6da2ba7c2646c68ad538ce95L117-R127) [[3]](diffhunk://#diff-1f4b6a605f0b4df4f1f874209b84a8c68eab4b5a6da2ba7c2646c68ad538ce95L174-R195) [[4]](diffhunk://#diff-1f4b6a605f0b4df4f1f874209b84a8c68eab4b5a6da2ba7c2646c68ad538ce95L190-L193) [[5]](diffhunk://#diff-1f4b6a605f0b4df4f1f874209b84a8c68eab4b5a6da2ba7c2646c68ad538ce95L208-R226)
* Memoized update callbacks for sensor form data in the comparison page to prevent unnecessary re-renders and improve performance.

**Code Cleanup**
* Removed unused code related to last updated time and data refresh logic from the comparison page.