### PR TITLE
Sensor identifier

### DIFF
--- a/src/components/dashboard/sensors/CheckboxGroup.tsx
+++ b/src/components/dashboard/sensors/CheckboxGroup.tsx
@@ -3,7 +3,7 @@ import { Checkbox } from "@heroui/react";
 
 interface CheckboxGroupProps {
   id: string;
-  label: string;
+  label: string | React.ReactNode;
   checked: boolean;
   indeterminate?: boolean;
   onChange: (checked: boolean) => void;
@@ -41,7 +41,7 @@ export const CheckboxGroup: React.FC<CheckboxGroupProps> = ({
         radius="md"
         size="lg"
         color="primary"
-        aria-label={label}
+        aria-label={typeof label === 'string' ? label : id}
       >
         {label}
       </Checkbox>

--- a/src/components/dashboard/sensors/FootfallCamBadge.tsx
+++ b/src/components/dashboard/sensors/FootfallCamBadge.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Tooltip } from "@heroui/react";
+
+interface FootfallCamBadgeProps {
+  className?: string;
+}
+
+export const FootfallCamBadge: React.FC<FootfallCamBadgeProps> = ({ 
+  className = "" 
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Tooltip
+      content={t("sensors.provider.footfallcam", "Proveedor: FootfallCam")}
+      placement="top"
+      showArrow
+    >
+      <div 
+        className={`inline-flex items-center justify-center px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full border border-blue-200 ${className}`}
+        title={t("sensors.provider.footfallcam", "Proveedor: FootfallCam")}
+      >
+        <span className="font-bold">FFC</span>
+      </div>
+    </Tooltip>
+  );
+};

--- a/src/components/dashboard/sensors/ProviderBadge.tsx
+++ b/src/components/dashboard/sensors/ProviderBadge.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Tooltip } from "@heroui/react";
+
+interface ProviderBadgeProps {
+  provider: string;
+  className?: string;
+}
+
+export const ProviderBadge: React.FC<ProviderBadgeProps> = ({ 
+  provider, 
+  className = "" 
+}) => {
+  const { t } = useTranslation();
+
+  // Define provider-specific styling and labels
+  const getProviderConfig = (providerName: string) => {
+    switch (providerName.toLowerCase()) {
+      case "footfallcam":
+      case "footfallcamv9api":
+        return {
+          label: "FFC",
+          bgColor: "bg-blue-100",
+          textColor: "text-blue-800",
+          borderColor: "border-blue-200",
+          tooltip: t("sensors.provider.footfallcam", "Proveedor: FootfallCam")
+        };
+      case "xovis":
+        return {
+          label: "XOV",
+          bgColor: "bg-green-100",
+          textColor: "text-green-800",
+          borderColor: "border-green-200",
+          tooltip: t("sensors.provider.xovis", "Proveedor: Xovis")
+        };
+      case "hella":
+        return {
+          label: "HEL",
+          bgColor: "bg-purple-100",
+          textColor: "text-purple-800",
+          borderColor: "border-purple-200",
+          tooltip: t("sensors.provider.hella", "Proveedor: Hella")
+        };
+      default:
+        return {
+          label: providerName.substring(0, 3).toUpperCase(),
+          bgColor: "bg-gray-100",
+          textColor: "text-gray-800",
+          borderColor: "border-gray-200",
+          tooltip: t("sensors.provider.unknown", "Proveedor: {{provider}}", { provider: providerName })
+        };
+    }
+  };
+
+  const config = getProviderConfig(provider);
+
+  return (
+    <Tooltip
+      content={config.tooltip}
+      placement="top"
+      showArrow
+    >
+      <div 
+        className={`inline-flex items-center justify-center px-2 py-1 text-xs font-medium rounded-full border ${config.bgColor} ${config.textColor} ${config.borderColor} ${className}`}
+        title={config.tooltip}
+      >
+        <span className="font-bold">{config.label}</span>
+      </div>
+    </Tooltip>
+  );
+};

--- a/src/components/dashboard/sensors/SensorSelectionModal.tsx
+++ b/src/components/dashboard/sensors/SensorSelectionModal.tsx
@@ -11,6 +11,7 @@ import {
   AccordionItem,
 } from "@heroui/react";
 import { CheckboxGroup } from "./CheckboxGroup";
+import { ProviderBadge } from "./ProviderBadge";
 import { sensorMetadata } from "../../../types/sensorMetadata";
 import { SensorLocation } from "../../../types/sensorLocation.ts";
 
@@ -177,7 +178,17 @@ const SensorSelectionModal: React.FC<SensorSelectionModalProps> = ({
                         <CheckboxGroup
                           key={`sensor-${location.id}-${sensor.id}`}
                           id={`sensor-${location.id}-${sensor.id}`}
-                          label={sensor.position}
+                          label={
+                            <div className="flex items-center gap-2">
+                              <span>{sensor.position}</span>
+                              {typeof sensor.provider === "string" && /footfallcam/i.test(sensor.provider) && (
+                                <ProviderBadge 
+                                  provider="FootfallCam" 
+                                  className="ml-1"
+                                />
+                              )}
+                            </div>
+                          }
                           checked={localSelectedSensors.has(sensor.id)}
                           onChange={(checked) =>
                             handleSensorChange(sensor.id, checked)

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -252,6 +252,14 @@
       "toggle": "Compare periods"
     }
   },
+  "sensors": {
+    "provider": {
+      "footfallcam": "Provider: FootfallCam",
+      "xovis": "Provider: Xovis",
+      "hella": "Provider: Hella",
+      "unknown": "Provider: {{provider}}"
+    }
+  },
   "chart": {
     "in": "Entries",
     "out": "Exits"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -251,6 +251,14 @@
       "toggle": "Comparar períodos"
     }
   },
+  "sensors": {
+    "provider": {
+      "footfallcam": "Proveedor: FootfallCam",
+      "xovis": "Proveedor: Xovis",
+      "hella": "Proveedor: Hella",
+      "unknown": "Proveedor: {{provider}}"
+    }
+  },
   "chart": {
     "in": "Entradas",
     "out": "Salidas"

--- a/src/types/sensorMetadata.d.ts
+++ b/src/types/sensorMetadata.d.ts
@@ -1,4 +1,5 @@
 export type sensorMetadata = {
   id: number;
   position: string;
+  provider?: string; // "FootfallCam", "Xovis", "Hella", etc.
 };


### PR DESCRIPTION
This pull request introduces provider badges for sensors in the dashboard and improves the flexibility and accessibility of sensor selection components. The main changes include adding a reusable `ProviderBadge` component for visual identification of sensor providers, updating the sensor selection modal to display these badges, and enhancing internationalization support for provider labels. Additionally, the `CheckboxGroup` component now accepts more flexible label types and improves accessibility for non-string labels.

**Provider badge integration and UI improvements:**

* Added a new `ProviderBadge` component in `ProviderBadge.tsx` that displays a stylized badge and tooltip for each sensor provider, supporting FootfallCam, Xovis, Hella, and a generic fallback for unknown providers.
* Updated the `SensorSelectionModal.tsx` to show a `ProviderBadge` next to the sensor position label for FootfallCam sensors, improving visual clarity of sensor types in the selection UI. [[1]](diffhunk://#diff-04937b00ea196f6a10cdcded7eabf95d9260323371bd83ee837787918c173f4cR14) [[2]](diffhunk://#diff-04937b00ea196f6a10cdcded7eabf95d9260323371bd83ee837787918c173f4cL180-R191)

**Internationalization enhancements:**

* Added English and Spanish translations for sensor provider labels in `en.json` and `es.json`, ensuring tooltips and badges are localized. [[1]](diffhunk://#diff-85a7f9f12f8ccede1618ba1ef3c66c7b8cbb6da984cd2ef77af1400672330e31R255-R262) [[2]](diffhunk://#diff-3d2b8ccdb3850b6099424cae3ce1892730315e9c6819a3761c0bc0c336937d23R254-R261)

**Component flexibility and accessibility:**

* Modified the `CheckboxGroup` component to accept `label` as either a string or a React node, allowing for richer label content including badges.
* Improved accessibility in `CheckboxGroup` by dynamically setting `aria-label` based on whether the label is a string or a React node.