### PR TITLE
fix: routes

### DIFF
--- a/src/services/reportLayoutService.ts
+++ b/src/services/reportLayoutService.ts
@@ -298,7 +298,7 @@ class ReportLayoutServiceClass {
     try {
       // Try to save to API first
       const response = await axiosPrivate.post(
-        "/api/reports/layouts/placements",
+        "/reports/layouts/placements",
         {
           layoutId,
           widgetPlacements,
@@ -333,7 +333,7 @@ class ReportLayoutServiceClass {
     try {
       // Try to load from API first
       const response = await axiosPrivate.get(
-        `/api/reports/layouts/placements/${layoutId}`,
+        `/reports/layouts/placements/${layoutId}`,
       );
 
       if (response.status === 200 && response.data) {
@@ -437,7 +437,7 @@ class ReportLayoutServiceClass {
     try {
       // Try to fetch from API first
       const response = await axiosPrivate.get(
-        "/api/reports/layouts/configurations",
+        "/reports/layouts/configurations",
       );
 
       if (response.status === 200) {


### PR DESCRIPTION
This pull request updates the API endpoint paths in the `ReportLayoutServiceClass` to remove the `/api` prefix. The changes ensure consistency with the backend routing and may be required for compatibility with recent API updates.

API endpoint updates:

* Changed the POST endpoint for saving widget placements from `"/api/reports/layouts/placements"` to `"/reports/layouts/placements"` in `src/services/reportLayoutService.ts`.
* Changed the GET endpoint for loading widget placements from `"/api/reports/layouts/placements/${layoutId}"` to `"/reports/layouts/placements/${layoutId}"` in `src/services/reportLayoutService.ts`.
* Changed the GET endpoint for fetching layout configurations from `"/api/reports/layouts/configurations"` to `"/reports/layouts/configurations"` in `src/services/reportLayoutService.ts`.