### PR TITLE
Dev

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import ConnectionsPageWrapper from "./pages/connections-wrapper.tsx";
 import Overview from "./pages/overview.tsx";
 import ReportsPage from "./pages/reports.tsx";
 import FaqPage from "./pages/faq.tsx";
+import FreeTrialWrapper from "./pages/free-trial.tsx";
 
 function AppLayoutWithState() {
   const { isOpen, handleToggle, handleClose } = useSidebar();
@@ -65,6 +66,8 @@ function App() {
             path="/auth/change-password"
             element={<ChangePasswordPage />}
           />
+          <Route path="/free-trial" element={<FreeTrialWrapper />} />
+
           <Route element={<PrivateRoute />}>
             <Route path="/home" element={<RoleRedirect />} />
             <Route element={<AppLayoutWithState />}>

--- a/src/hooks/useSensorData.ts
+++ b/src/hooks/useSensorData.ts
@@ -1,6 +1,8 @@
 import { sensorResponse } from "../types/deviceResponse";
 import { useEffect, useState } from "react";
 import { axiosPrivate } from "../services/axiosClient.ts";
+import { mockSensorData } from "../utils/dataUtils";
+import { getUserRoleFromToken } from "./auth/useAuth";
 
 function useSensorData() {
   const [sensors, setSensors] = useState<sensorResponse[]>([]);
@@ -13,6 +15,15 @@ function useSensorData() {
       setError(null);
       setLoading(true);
       try {
+        const userRole = getUserRoleFromToken();
+        if (!userRole) {
+          setTimeout(() => {
+            setSensors(mockSensorData);
+            setLoading(false);
+          }, 500);
+          return;
+        }
+
         const response = await axiosPrivate.get("/devices/accessible", {});
         if (response.status !== 200) {
           setError("Error fetching sensors");

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -304,7 +304,8 @@
       "advancedComparisonsDesc": "Compare metrics across locations and time periods",
       "keyMetrics": "Key Metrics",
       "keyMetricsDesc": "Track entries, exits, and conversion rates"
-    }
+    },
+    "tryFreeDemo": "Try Demo"
   },
   "login": {
     "welcome": "Welcome back!",
@@ -570,5 +571,9 @@
       "saveErrorDesc": "There was an error saving the report configuration.",
       "timezoneErrorTitle": "Invalid Timezone"
     }
+  },
+  "freeTrial": {
+    "demoNotice": "You are viewing a demo. Data is for illustration only.",
+    "login": "Log In"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -303,7 +303,8 @@
       "advancedComparisonsDesc": "Compara métricas entre ubicaciones y periodos de tiempo",
       "keyMetrics": "Métricas Clave",
       "keyMetricsDesc": "Sigue entradas, salidas y tasas de conversión"
-    }
+    },
+    "tryFreeDemo": "Prueba la Demo"
   },
   "login": {
     "welcome": "¡Bienvenido de nuevo!",
@@ -574,5 +575,9 @@
     "password": "Password",
     "userPlaceholder": "Enter username",
     "passwordPlaceholder": "Enter password"
+  },
+  "freeTrial": {
+    "demoNotice": "Estás viendo una demostración. Los datos son solo ilustrativos.",
+    "login": "Iniciar sesión"
   }
 }

--- a/src/pages/free-trial.tsx
+++ b/src/pages/free-trial.tsx
@@ -1,0 +1,53 @@
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { useLanguage } from "../hooks/useLanguage";
+import { LanguageIcon } from "@heroicons/react/24/outline";
+import Dashboard from "./dashboard";
+
+const FreeTrialWrapper = () => {
+  const navigate = useNavigate();
+  const { t } = useTranslation();
+  const { toggleLanguage, currentLanguage } = useLanguage();
+
+  return (
+    <div className="min-h-screen bg-white flex flex-col relative">
+      {/* Free Trial Status Bar */}
+      <div className="w-full flex items-center justify-between px-4 py-2 bg-primary text-white text-sm z-20">
+        <span>
+          {t(
+            "freeTrial.demoNotice",
+            "You are viewing a demo. Data is for illustration only.",
+          )}
+        </span>
+        <button
+          onClick={() => navigate("/login")}
+          className="px-4 py-1 bg-white text-primary rounded-md font-medium text-sm hover:bg-primary-100 transition"
+        >
+          {t("freeTrial.login", "Log In")}
+        </button>
+      </div>
+
+      {/* Language Switch Button - right aligned below status bar */}
+      <div className="w-full flex justify-end px-4 py-2">
+        <button
+          onClick={toggleLanguage}
+          className="flex items-center gap-2 rounded-full p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-600"
+          title={t("common.changeLanguage", "Change language")}
+          aria-label={t("common.changeLanguage", "Change language")}
+        >
+          <LanguageIcon className="h-5 w-5" />
+          <span className="text-xs font-medium">
+            {currentLanguage.toUpperCase()}
+          </span>
+        </button>
+      </div>
+
+      {/* Dashboard fills the rest */}
+      <div className="flex-1 w-full">
+        <Dashboard /* demoMode={true} */ />
+      </div>
+    </div>
+  );
+};
+
+export default FreeTrialWrapper;

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -115,8 +115,8 @@ const Landing = () => {
             )}
           </p>
 
-          {/* Dashboard Button */}
-          <div className="flex justify-center">
+          {/* Dashboard & Free Demo Buttons */}
+          <div className="flex flex-col items-center gap-4 mt-4">
             <button
               onClick={() => navigate("/home")}
               className="px-8 py-3 bg-[#00A5B1] text-white text-lg font-medium rounded-md
@@ -126,6 +126,14 @@ const Landing = () => {
               <span className="ml-2 transform transition-transform group-hover:translate-x-1">
                 →
               </span>
+            </button>
+            <button
+              onClick={() => navigate("/free-trial")}
+              className="px-8 py-3 bg-white border border-[#00A5B1] text-[#00A5B1] text-lg font-medium rounded-md
+                hover:bg-[#00A5B1] hover:text-white transition-all flex items-center justify-center shadow-lg shadow-[#00A5B1]/10"
+            >
+              {t("landing.tryFreeDemo", "Try Free Demo")}
+              <span className="ml-2">🚀</span>
             </button>
           </div>
         </div>

--- a/src/utils/dataUtils.ts
+++ b/src/utils/dataUtils.ts
@@ -1,0 +1,108 @@
+import { sensorResponse } from "../types/deviceResponse";
+import { SensorDataPoint } from "../types/sensorDataResponse.ts";
+
+export const mockSensorData: sensorResponse[] = [
+  {
+    id: "1",
+    name: "Street market",
+    sensors: [
+      {
+        id: 7,
+        position: "South Wing 1",
+        provider: "FootFallCam",
+      },
+      {
+        id: 8,
+        position: "North Wing 2",
+        provider: "Xovis",
+      },
+      {
+        id: 9,
+        position: "South Wing 3",
+        provider: "FootFallCam",
+      },
+      {
+        id: 10,
+        position: "Exit Door 1",
+        provider: "Xovis",
+      },
+      {
+        id: 11,
+        position: "Emergency Exit 2",
+        provider: "Xovis",
+      },
+    ],
+  },
+  {
+    id: "4",
+    name: "Riverside Outlets",
+    sensors: [
+      {
+        id: 18,
+        position: "North Wing 1",
+        provider: "FootFallCam",
+      },
+      {
+        id: 19,
+        position: "Entertainment Zone 2",
+        provider: "FootFallCam",
+      },
+      {
+        id: 20,
+        position: "Side Entrance 1",
+        provider: "Xovis",
+      },
+      {
+        id: 21,
+        position: "Exit Door 2",
+        provider: "Xovis",
+      },
+    ],
+  },
+];
+
+export const generateMockSensorData = (
+  startDate: Date,
+  endDate: Date,
+  sensorIds: number[],
+): SensorDataPoint[] => {
+  const mockData: SensorDataPoint[] = [];
+  const currentDate = new Date(startDate);
+
+  // Find the relevant locations for the requested sensors
+  const relevantLocations = mockSensorData.filter((location) =>
+    location.sensors.some((sensor) => sensorIds.includes(sensor.id)),
+  );
+
+  while (currentDate <= endDate) {
+    // Generate data for each 5-minute interval
+    const timestamp = currentDate.toISOString();
+
+    // Generate realistic random data based on number of relevant locations
+    // This simulates the merging behavior that happens in useFetchData
+    const locationMultiplier = relevantLocations.length || 1;
+
+    const total_count_in =
+      Math.floor(Math.random() * 25 * locationMultiplier) + 5;
+    const total_count_out =
+      Math.floor(Math.random() * 20 * locationMultiplier) + 3;
+    const outsideTraffic =
+      Math.floor(Math.random() * 100 * locationMultiplier) + 50;
+    const avgVisitDuration = Math.random() * 30 + 10; // Average doesn't multiply
+    const returningCustomer = Math.floor(Math.random() * 60) + 20; // Percentage doesn't multiply
+
+    mockData.push({
+      timestamp,
+      total_count_in,
+      total_count_out,
+      outsideTraffic,
+      avgVisitDuration,
+      returningCustomer,
+    });
+
+    // Increment by 5 minutes
+    currentDate.setMinutes(currentDate.getMinutes() + 5);
+  }
+
+  return mockData;
+};


### PR DESCRIPTION
This pull request introduces a free trial/demo mode to the app, allowing unauthenticated users to explore a simulated dashboard experience with mock data. It adds a dedicated "Free Demo" entry point from the landing page, a new `/free-trial` route, and ensures all sensor data and records are populated with realistic mock data when in demo mode. The changes also include internationalization updates for demo-related UI and messaging. Below are the most important changes grouped by theme:

**Free Trial/Demo Mode Feature:**

* Added a new `FreeTrialWrapper` component (`src/pages/free-trial.tsx`) that displays a demo status bar, a login button, a language switcher, and embeds the dashboard for demo users.
* Registered the `/free-trial` route in `src/App.tsx` and imported the new wrapper component. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R29) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R69-R70)
* Updated the landing page to include a "Try Free Demo" button that navigates to the new demo mode. [[1]](diffhunk://#diff-51c32d14ed4f0e6d704c079a3e691551f49d29aeb5b9ac175b4bcc6cd1428e65L118-R119) [[2]](diffhunk://#diff-51c32d14ed4f0e6d704c079a3e691551f49d29aeb5b9ac175b4bcc6cd1428e65R130-R137)

**Mock Data Logic for Demo Users:**

* Created `mockSensorData` and `generateMockSensorData` utilities in `src/utils/dataUtils.ts` to provide realistic sensor and record data for demo mode.
* Modified `useSensorData` and `useSensorRecords` hooks to detect unauthenticated users and serve mock data instead of making API calls. [[1]](diffhunk://#diff-5f33aef7d346c0bdb1f4d7aa53d123c405ed3748602913b8452feaa3048eff7eR4-R5) [[2]](diffhunk://#diff-5f33aef7d346c0bdb1f4d7aa53d123c405ed3748602913b8452feaa3048eff7eR18-R26) [[3]](diffhunk://#diff-1f4b6a605f0b4df4f1f874209b84a8c68eab4b5a6da2ba7c2646c68ad538ce95R15-R16) [[4]](diffhunk://#diff-1f4b6a605f0b4df4f1f874209b84a8c68eab4b5a6da2ba7c2646c68ad538ce95R68-R89) [[5]](diffhunk://#diff-1f4b6a605f0b4df4f1f874209b84a8c68eab4b5a6da2ba7c2646c68ad538ce95R156-R180)

**Internationalization Updates:**

* Added new strings and demo notices for free trial mode in both English (`src/i18n/en.json`) and Spanish (`src/i18n/es.json`). [[1]](diffhunk://#diff-85a7f9f12f8ccede1618ba1ef3c66c7b8cbb6da984cd2ef77af1400672330e31L307-R308) [[2]](diffhunk://#diff-85a7f9f12f8ccede1618ba1ef3c66c7b8cbb6da984cd2ef77af1400672330e31R574-R577) [[3]](diffhunk://#diff-3d2b8ccdb3850b6099424cae3ce1892730315e9c6819a3761c0bc0c336937d23L306-R307) [[4]](diffhunk://#diff-3d2b8ccdb3850b6099424cae3ce1892730315e9c6819a3761c0bc0c336937d23R578-R581)