### PR TITLE
fix comparison chart date ordering when range > 1 month

### DIFF
--- a/src/components/dashboard/layout-dashboard/widgets/ChartWidgets.tsx
+++ b/src/components/dashboard/layout-dashboard/widgets/ChartWidgets.tsx
@@ -13,6 +13,7 @@ import { WidgetConfig, WidgetFactoryParams } from "./types";
 import { useTranslation } from "react-i18next";
 import React from "react";
 import { VisitDurationDistribution } from "../../charts/visit-duration-distribution";
+import { parse } from "date-fns";
 
 const NoDataMessage = () => {
   const { t } = useTranslation();
@@ -371,7 +372,12 @@ export const ChartWidgets = {
               }
               return acc;
             }, [] as string[])
-            .sort();
+            .sort((a: string, b: string) => {
+              // Parse timestamps in format "MMM dd, HH:mm" and sort chronologically
+              const dateA = parse(a, "MMM dd, HH:mm", new Date());
+              const dateB = parse(b, "MMM dd, HH:mm", new Date());
+              return dateA.getTime() - dateB.getTime();
+            });
 
           // Filter locations that have valid data
           const validLocations = params.sensorDataByLocation.filter(


### PR DESCRIPTION
This pull request enhances the sorting logic for chart widgets in the dashboard, ensuring that timestamped data is now sorted chronologically rather than alphabetically. This improves the accuracy and usability of the displayed data.

**Chart data sorting improvements:**

* Updated the sorting function in `ChartWidgets` to parse timestamps in the format `"MMM dd, HH:mm"` and sort them by chronological order instead of simple string comparison. (`src/components/dashboard/layout-dashboard/widgets/ChartWidgets.tsx`)

**Dependency update:**

* Added an import for the `parse` function from `date-fns` to support the new timestamp parsing logic. (`src/components/dashboard/layout-dashboard/widgets/ChartWidgets.tsx`)